### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+From centos:7.8.2003
+ADD . /root
+RUN ln -s /root/node-v12.19.0-linux-x64/bin/node /usr/bin/node && ln -s /root/node-v12.19.0-linux-x64/bin/npm /usr/bin/npm && ln -s /root/node-v12.19.0-linux-x64/bin/npx /usr/bin/npx
+WORKDIR /root
+CMD ["node", "main","3449308644"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  miraiok:
+    network_mode: "host"
+    image: onebot:v1
+    restart: always
+    volumes:
+      - ./config.js:/root/config.js
+      - ./data:/root/data
+    stdin_open: true
+    tty: true
+    container_name: docker-onebot3


### PR DESCRIPTION
构建docker image需要用户自己决定nodejs版本，这里以node-v12.19.0-linux-x64.tar为例，下载到工程路径并解压后，改一下dockerfile里ln软链的原地址，例如
```
RUN ln -s /root/node-v12.19.0-linux-x64/bin/node /usr/bin/node && ln -s /root/node-v12.19.0-linux-x64/bin/npm /usr/bin/npm && ln -s /root/node-v12.19.0-linux-x64/bin/npx /usr/bin/npx

改成
RUN ln -s /root/${你的版本}/bin/node /usr/bin/node && ln -s /root/${你的版本}/bin/npm /usr/bin/npm && ln -s /root/${你的版本}/bin/npx /usr/bin/npx

```

启动命令请改成自己的QQ号
```
CMD ["node", "main","3449308644"]

改成

CMD ["node", "main","${自己的qq号}"]
```

然后就可以build镜像了
```
docker build -t onebot:v1 . 
```

然后用docker-compose启动
```
docker-compose up -d
```
